### PR TITLE
fix(ci): unblock EMFILE install/build failures and release auth

### DIFF
--- a/.github/workflows/combined-tests.yml
+++ b/.github/workflows/combined-tests.yml
@@ -38,9 +38,12 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps
 
+      - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
+        run: npm install --no-save --no-package-lock graceful-fs
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
+          NODE_OPTIONS: --require=graceful-fs/polyfill.js
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/combined-tests.yml
+++ b/.github/workflows/combined-tests.yml
@@ -39,11 +39,16 @@ jobs:
         run: bunx playwright install --with-deps
 
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
-        run: npm install --no-save --no-package-lock graceful-fs
+        run: |
+          npm install --no-save --no-package-lock graceful-fs
+          cat > /tmp/gfs-preload.cjs <<'EOF'
+          const gfs = require('graceful-fs');
+          gfs.gracefulify(require('fs'));
+          EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=graceful-fs/polyfill.js
+          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/combined-tests.yml
+++ b/.github/workflows/combined-tests.yml
@@ -39,8 +39,11 @@ jobs:
         run: bunx playwright install --with-deps
 
       - name: Build application
+        env:
+          UV_THREADPOOL_SIZE: "4"
         run: |
-          ulimit -n 65536
+          ulimit -n 1048576 || ulimit -n 65536
+          echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"
           bun run build
 
       - name: Save build folder

--- a/.github/workflows/combined-tests.yml
+++ b/.github/workflows/combined-tests.yml
@@ -38,11 +38,10 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps
 
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
-
       - name: Build application
-        run: bun run build
+        run: |
+          ulimit -n 65536
+          bun run build
 
       - name: Save build folder
         uses: actions/upload-artifact@v5

--- a/.github/workflows/combined-tests.yml
+++ b/.github/workflows/combined-tests.yml
@@ -41,14 +41,13 @@ jobs:
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
         run: |
           npm install --no-save --no-package-lock graceful-fs
-          cat > /tmp/gfs-preload.cjs <<'EOF'
-          const gfs = require('graceful-fs');
-          gfs.gracefulify(require('fs'));
+          cat > ./gfs-preload.cjs <<'EOF'
+          require('graceful-fs').gracefulify(require('fs'));
           EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
+          NODE_OPTIONS: --require=./gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,8 +44,11 @@ jobs:
         run: bun install
 
       - name: Build application
+        env:
+          UV_THREADPOOL_SIZE: "4"
         run: |
-          ulimit -n 65536
+          ulimit -n 1048576 || ulimit -n 65536
+          echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"
           bun run build
 
       - name: Save build folder

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,11 +44,16 @@ jobs:
         run: bun install
 
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
-        run: npm install --no-save --no-package-lock graceful-fs
+        run: |
+          npm install --no-save --no-package-lock graceful-fs
+          cat > /tmp/gfs-preload.cjs <<'EOF'
+          const gfs = require('graceful-fs');
+          gfs.gracefulify(require('fs'));
+          EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=graceful-fs/polyfill.js
+          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -46,14 +46,13 @@ jobs:
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
         run: |
           npm install --no-save --no-package-lock graceful-fs
-          cat > /tmp/gfs-preload.cjs <<'EOF'
-          const gfs = require('graceful-fs');
-          gfs.gracefulify(require('fs'));
+          cat > ./gfs-preload.cjs <<'EOF'
+          require('graceful-fs').gracefulify(require('fs'));
           EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
+          NODE_OPTIONS: --require=./gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,11 +43,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
-
       - name: Build application
-        run: bun run build
+        run: |
+          ulimit -n 65536
+          bun run build
 
       - name: Save build folder
         uses: actions/upload-artifact@v5

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
+        run: npm install --no-save --no-package-lock graceful-fs
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
+          NODE_OPTIONS: --require=graceful-fs/polyfill.js
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,9 +45,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
+        run: npm install --no-save --no-package-lock graceful-fs
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
+          NODE_OPTIONS: --require=graceful-fs/polyfill.js
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -48,14 +48,13 @@ jobs:
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
         run: |
           npm install --no-save --no-package-lock graceful-fs
-          cat > /tmp/gfs-preload.cjs <<'EOF'
-          const gfs = require('graceful-fs');
-          gfs.gracefulify(require('fs'));
+          cat > ./gfs-preload.cjs <<'EOF'
+          require('graceful-fs').gracefulify(require('fs'));
           EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
+          NODE_OPTIONS: --require=./gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,8 +46,11 @@ jobs:
         run: bun install
 
       - name: Build application
+        env:
+          UV_THREADPOOL_SIZE: "4"
         run: |
-          ulimit -n 65536
+          ulimit -n 1048576 || ulimit -n 65536
+          echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"
           bun run build
 
       - name: Cache Playwright browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,11 +46,16 @@ jobs:
         run: bun install
 
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
-        run: npm install --no-save --no-package-lock graceful-fs
+        run: |
+          npm install --no-save --no-package-lock graceful-fs
+          cat > /tmp/gfs-preload.cjs <<'EOF'
+          const gfs = require('graceful-fs');
+          gfs.gracefulify(require('fs'));
+          EOF
       - name: Build application
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=graceful-fs/polyfill.js
+          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,11 +45,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
-
       - name: Build application
-        run: bun run build
+        run: |
+          ulimit -n 65536
+          bun run build
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # Prefer a PAT so release tags trigger downstream workflows; fall
+          # back to the built-in token so the job still runs if the secret
+          # is not yet configured.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -22,14 +22,13 @@ jobs:
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
         run: |
           npm install --no-save --no-package-lock graceful-fs
-          cat > /tmp/gfs-preload.cjs <<'EOF'
-          const gfs = require('graceful-fs');
-          gfs.gracefulify(require('fs'));
+          cat > ./gfs-preload.cjs <<'EOF'
+          require('graceful-fs').gracefulify(require('fs'));
           EOF
       - name: Build
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
+          NODE_OPTIONS: --require=./gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -19,11 +19,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
-
       - name: Build
-        run: bun run build
+        run: |
+          ulimit -n 65536
+          bun run build
 
       - name: Create Sentry release
         uses: getsentry/action-release@v3

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -20,11 +20,16 @@ jobs:
         run: bun install
 
       - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
-        run: npm install --no-save --no-package-lock graceful-fs
+        run: |
+          npm install --no-save --no-package-lock graceful-fs
+          cat > /tmp/gfs-preload.cjs <<'EOF'
+          const gfs = require('graceful-fs');
+          gfs.gracefulify(require('fs'));
+          EOF
       - name: Build
         env:
           UV_THREADPOOL_SIZE: "4"
-          NODE_OPTIONS: --require=graceful-fs/polyfill.js
+          NODE_OPTIONS: --require=/tmp/gfs-preload.cjs
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -19,9 +19,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install graceful-fs (CI-only, to survive EMFILE from magicast/recast)
+        run: npm install --no-save --no-package-lock graceful-fs
       - name: Build
         env:
           UV_THREADPOOL_SIZE: "4"
+          NODE_OPTIONS: --require=graceful-fs/polyfill.js
         run: |
           ulimit -n 1048576 || ulimit -n 65536
           echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -20,8 +20,11 @@ jobs:
         run: bun install
 
       - name: Build
+        env:
+          UV_THREADPOOL_SIZE: "4"
         run: |
-          ulimit -n 65536
+          ulimit -n 1048576 || ulimit -n 65536
+          echo "fd soft limit: $(ulimit -Sn) / hard limit: $(ulimit -Hn)"
           bun run build
 
       - name: Create Sentry release

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,14 +37,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
-
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           browser: ${{ matrix.browsers }}
-          build: bun run build
+          build: bash -c 'ulimit -n 65536 && bun run build'
           start: bun run start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 120
@@ -74,9 +71,6 @@ jobs:
 
       - name: Install Playwright Browsers
         run: bunx playwright install --with-deps
-
-      - name: Increase file descriptor limit
-        run: ulimit -n 65536
 
       - name: Start server for testing (background)
         run: bun run start &

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,8 +1,8 @@
-import { createRequire } from "node:module";
 import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import tailwindcss from "@tailwindcss/vite";
 import type { TanStackStartInputConfig } from "@tanstack/react-start/config";
 import { defineConfig } from "@tanstack/react-start/config";
+import { createRequire } from "node:module";
 import { VitePWA } from "vite-plugin-pwa";
 import tsConfigPaths from "vite-tsconfig-paths";
 
@@ -64,18 +64,27 @@ const config = defineConfig({
   },
 
   // https://react.dev/learn/react-compiler
-  react: {
-    babel: {
-      plugins: [
-        [
-          "babel-plugin-react-compiler",
-          {
-            target: "19",
-          },
-        ],
-      ],
-    },
-  },
+  // babel-plugin-react-compiler uses recast, which opens ast-types' .d.ts
+  // files on every transform. For an app with many route/component files the
+  // aggregate FD usage blows past the GHA runner's hard cap (65536) and
+  // crashes the build with EMFILE. Skip the compiler plugin in CI; tests
+  // don't need the compiled output. Sentry/release builds in CI lose this
+  // optimization too, which is acceptable - production ships from Vercel,
+  // not from CI artifacts.
+  react: process.env.CI
+    ? {}
+    : {
+        babel: {
+          plugins: [
+            [
+              "babel-plugin-react-compiler",
+              {
+                target: "19",
+              },
+            ],
+          ],
+        },
+      },
 
   server: {
     /**

--- a/app.config.ts
+++ b/app.config.ts
@@ -40,7 +40,7 @@ const config = defineConfig({
         workbox: {
           cleanupOutdatedCaches: true,
           globPatterns: ["**/*"],
-          maximumFileSizeToCacheInBytes: ((1024 * 2) ** 2) //
+          maximumFileSizeToCacheInBytes: (1024 * 2) ** 2, //
         },
         registerType: "autoUpdate",
         injectRegister: "auto",
@@ -57,7 +57,7 @@ const config = defineConfig({
       external: ["@tanstack/react-query", "@tanstack/react-query-devtools"],
     },
     esbuild: {
-      drop: ['console', 'debugger'], // Drop console statements in production
+      drop: ["console", "debugger"], // Drop console statements in production
     },
   },
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,4 @@
-import MillionLint from "@million/lint";
+import { createRequire } from "node:module";
 import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import tailwindcss from "@tailwindcss/vite";
 import type { TanStackStartInputConfig } from "@tanstack/react-start/config";
@@ -20,13 +20,15 @@ const config = defineConfig({
         projects: ["./tsconfig.json"],
       }),
       tailwindcss(),
-      // Million Lint is a dev-time profiler. In CI it inflates the number of
-      // concurrent file opens via recast/ast-types and triggers EMFILE during
-      // `vinxi build` on GitHub-hosted runners. Skip it when CI=true.
+      // Million Lint is a dev-time profiler. Its package pulls in recast +
+      // ast-types whose module-init reads dozens of .d.ts files in parallel,
+      // which blows past the GHA runner's hard fd cap (65536) during
+      // `vinxi build`. Load it lazily (and only outside CI) so static import
+      // side effects never run on the runner.
       ...(process.env.CI
         ? []
         : [
-            MillionLint.vite({
+            createRequire(import.meta.url)("@million/lint").default.vite({
               react: "19",
               lite: true,
               filter: {

--- a/app.config.ts
+++ b/app.config.ts
@@ -20,16 +20,22 @@ const config = defineConfig({
         projects: ["./tsconfig.json"],
       }),
       tailwindcss(),
-      MillionLint.vite({
-        react: "19",
-        lite: true, // Enable lite mode for faster builds
-        filter: {
-          // Limit scope to only your app components
-          include: "**/components/**/*.{tsx,jsx}",
-          exclude: "**/node_modules/**/*"
-        },
-        optimizeDOM: false, // Disable DOM optimization to reduce complexity
-      }),
+      // Million Lint is a dev-time profiler. In CI it inflates the number of
+      // concurrent file opens via recast/ast-types and triggers EMFILE during
+      // `vinxi build` on GitHub-hosted runners. Skip it when CI=true.
+      ...(process.env.CI
+        ? []
+        : [
+            MillionLint.vite({
+              react: "19",
+              lite: true,
+              filter: {
+                include: "**/components/**/*.{tsx,jsx}",
+                exclude: "**/node_modules/**/*",
+              },
+              optimizeDOM: false,
+            }),
+          ]),
       VitePWA({
         workbox: {
           cleanupOutdatedCaches: true,


### PR DESCRIPTION
## Summary

Fixes the CI infrastructure failures that were blocking every open PR (all 15 Dependabot) and every push to main. Does **not** fix the separate pre-existing application build bug around source-phase imports — that is filed as a follow-up issue.

### What changed

**1. EMFILE during `vinxi build` (Cypress, Playwright, Combined Testing, Sentry workflows)**

Every build on main + every Dependabot PR failed with:
```
[error] EMFILE: too many open files, open '.../recast/node_modules/ast-types/lib/def/es2017.d.ts'
```

Root cause: `magicast` (transitive via Vinxi/Nitro's route plugin) uses `recast`/`ast-types` during the router-client build phase, and its fan-out of `.d.ts` opens exceeds the GHA runner's hard FD cap (65536, confirmed by the diagnostic echo we added).

Fix layered defensively:
- Install `graceful-fs` transiently via `npm install --no-save --no-package-lock` in each CI build workflow (no `bun.lockb` churn) and preload it via `NODE_OPTIONS=--require=./gfs-preload.cjs`. The preload calls `gracefulify(fs)`, which queues EMFILE retries instead of crashing. Vinxi runs under Node via shebang, so the preload takes effect even though bun invokes it.
- Merge the `ulimit -n 65536` and `bun run build` steps into a single shell block (they were on separate `run:` lines, which GHA spawns in isolated shells — the fd limit never reached the build).
- Raise to `ulimit -n 1048576 || ulimit -n 65536` (fallback; runner hard cap is 65536, confirmed).
- Set `UV_THREADPOOL_SIZE=4` to cap libuv concurrency as belt-and-suspenders.
- Defense in depth: lazy-load Million Lint via `createRequire` (static import alone triggered the same module-init fd storm) and gate `babel-plugin-react-compiler` behind `!process.env.CI` (same recast-fan-out class of problem; tests don't need the compiled output).

**2. `release.yml` checkout auth**

Semantic-release failed with `fatal: could not read Username for 'https://github.com'` because `secrets.RELEASE_TOKEN` is unset. Added `|| github.token` fallback on both the checkout `token:` input and the `GITHUB_TOKEN` env so the workflow runs with the built-in token when the PAT is absent.

**3. Orphan `ulimit` step cleanup**

Removed a dead `ulimit -n 65536` step in `testing.yml`'s Playwright job that sat in its own shell and had no effect. For that file's Cypress job, pushed the ulimit through the `cypress-io/github-action@v6` `build:` input via `bash -c 'ulimit -n 65536 && bun run build'`.

## What this PR does NOT fix

The build itself still fails after install — but with a **different, pre-existing error** that was masked by the EMFILE crash. After this PR, builds run ~3 minutes (vs. crashing at 15s before) and produce:

```
Source phase import "..." must be external.
Source phase imports are only supported for external modules.
```

This error surfaces from multiple plugins in the stack (TanStack Router code-splitter's `?tsr-split=component`, `@tailwindcss/vite`'s `?transform-only`, `@sentry/react`'s internal reactrouterv6 shim, and even TanStack Start's own `createServerFn.js` using source-phase imports to `node:fs`). The installed rollup (4.34.9, bundled inside vite) does not support source-phase imports for internal modules, and has no public `experimentalSourcePhaseImports` opt-in (verified by rollup's own error listing allowed options).

This is a package-version coordination problem, not a CI or config problem. Follow-up issue to be filed.

## Test plan

- [ ] CI runs on this PR (combined-tests, cypress, playwright, sentry) — expected to fail at build with the source-phase error, NOT at install/EMFILE. Confirm the echo step prints `fd soft limit: 65536`.
- [ ] Verify the release workflow succeeds on next push to main (auth fallback).
- [ ] After merge: rebase Dependabot PRs to confirm they also get past EMFILE (and then fail identically at the source-phase bug, which is expected until that bug is fixed separately).
- [ ] Local `bun run build` still includes Million Lint, React Compiler, VitePWA, Sentry (CI-only gates do not activate outside CI).

## Follow-ups

- Enable branch protection on `main` (the commit that unmasked this CI break went direct to main, no review).
- The Playwright job in `testing.yml` calls `bun run start` without a prior build step — separate pre-existing issue.
- The main build bug (source-phase imports in rollup 4.34) — separate PR, needs a vite/rollup/TanStack coordinated upgrade.
