### PR TITLE
chore(git): ignore .claude/ tooling state; untrack scheduler lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"0a4d60c1-ccd8-49ef-a5a5-6274cbe85718","pid":80873,"procStart":"261262","acquiredAt":1776991370361}

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ sw.js.*
 .sentryclirc
 
 app.config.timestamp_*.js
+# Claude Code local state (settings, scheduled tasks, etc.)
+.claude/


### PR DESCRIPTION
## Summary

Stops tracking Claude Code's per-project local state:

- `.claude/scheduled_tasks.lock` leaked in via PR #135's merge. It's a runtime lock file for background watcher tasks - regenerated per session, churns diffs.
- Any future files Claude Code drops in `.claude/` (like the local permission allowlist at `.claude/settings.local.json`) also stay out of git.

### Changes

- `.gitignore` gains `.claude/`.
- `git rm --cached .claude/scheduled_tasks.lock` (keeps it on disk, removes from index).

Machine-local `.claude/settings.local.json` is not in the PR - it lives only on each contributor's machine.